### PR TITLE
add Trimage image compressor to list

### DIFF
--- a/src/tools/index.js
+++ b/src/tools/index.js
@@ -265,6 +265,13 @@ export default {
         link: 'https://imageoptim.com/api',
         title: 'ImageOptim',
         type: [api, external]
+      },
+      {
+        description:
+          'A GUI tool for losslessly optimizing PNG and JPG files',
+        link: 'https://trimage.org/',
+        title: 'Trimage',
+        type: [cli, external]
       }
     ]
   },


### PR DESCRIPTION
[Trimage](https://trimage.org/) is a GUI frontend for various image compression tools that I made that's available on Debian and Ubuntu (and other Debian based systems.) It also has a CLI.