### PR TITLE
Replacing invalid schema markup with json-ld syntax

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -11,10 +11,17 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<meta name="theme-color" content="#8E44AD">
 
-	<!-- Schema.org markup for Google+ -->
-	<meta itemprop="name" content="Progressive Tooling">
-	<meta itemprop="description" content="A curated list of progressive tools to optimize the performance of your web project">
-	<meta itemprop="image" content="https://i.imgur.com/kfedToy.png">
+	<!-- Schema.org markup for Google -->
+	<script type="application/ld+json">
+	{
+	  "@context": "http://schema.org/",
+	  "@type": "WebSite",
+	  "name": "Progressive Tooling",
+	  "description": "A curated list of progressive tools to optimize the performance of your web project",
+	  "url": "https://progressivetooling.com/",
+	  "image": "https://i.imgur.com/kfedToy.png"
+	}
+	</script>
 
 	<!-- Twitter Card data -->
 	<meta name="twitter:card" content="summary_large_image">


### PR DESCRIPTION
Previous markup missing both `itemscope` and `itemtype` and [isn't valid](https://search.google.com/structured-data/testing-tool/u/0/#url=https%3A%2F%2Fprogressivetooling.com%2F). Since not marked-up in body and in keeping this in the `<head>`, introducing JSON-LD instead, declaring type, etc.